### PR TITLE
Avoid multiple charges

### DIFF
--- a/views/templates/hook/payment.tpl
+++ b/views/templates/hook/payment.tpl
@@ -95,6 +95,8 @@ $(document).ready(function() {
 	Culqi.init();
 
 	$('#payment-confirmation > .ps-shown-by-js > button').click(function(e) {
+
+		$('#payment-confirmation > .ps-shown-by-js > button').prop("disabled",true);
 		var myPaymentMethodSelected = $('.payment-options').find("input[data-module-name='culqi']").is(':checked');
 
 		if(myPaymentMethodSelected) {


### PR DESCRIPTION
Luego del primer click en el boton "pedido con obligacion de pago", éste se desactiva evitando múltiples cargos por accidentes de múltiples clicks.